### PR TITLE
CLJS Web Worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,17 +9,24 @@
 .history
 .svn/
 migrate_working_dir/
+**/out/
+
+# Environment
+**/.envrc
+
+# Clojure
+**/.lsp/
+**/.cp-cache/
+**/.clj-kondo/
+**/.nrepl-port
 
 # IntelliJ related
 *.iml
 *.ipr
 *.iws
 .idea/
-
-# The .vscode folder contains launch configuration and tasks you configure in
-# VS Code which you may wish to be included in version control, so this line
-# is commented out by default.
-#.vscode/
+.vscode/
+.calva/
 
 # Flutter/Dart/Pub related
 **/doc/api/
@@ -31,6 +38,7 @@ migrate_working_dir/
 .pub-cache/
 .pub/
 /build/
+**/devtools_options.yaml
 
 # Symbolication related
 app.*.symbols

--- a/worker-cljs/.gitignore
+++ b/worker-cljs/.gitignore
@@ -1,0 +1,7 @@
+# Misc
+out/
+
+# Clojure
+.lsp/
+.cp-cache/
+.clj-kondo/

--- a/worker-cljs/bb.edn
+++ b/worker-cljs/bb.edn
@@ -1,0 +1,13 @@
+{:tasks
+ {compile {:doc "Compile to JS"
+           :requires ([babashka.fs :as fs]
+                      [clojure.string :as str])
+           :task (do 
+                   
+                   (->> ["clj -M -m cljs.main"
+                         "--optimizations advanced"
+                         "-c hti.re-dash-inspector.worker"]
+                        (str/join " ")
+                        shell)
+                   
+                   (fs/copy "out/main.js" "../worker.js" {:replace-existing true}))}}}

--- a/worker-cljs/deps.edn
+++ b/worker-cljs/deps.edn
@@ -1,0 +1,1 @@
+{:deps {org.clojure/clojurescript {:mvn/version "1.11.132"}}}

--- a/worker-cljs/src/hti/re_dash_inspector/worker.cljs
+++ b/worker-cljs/src/hti/re_dash_inspector/worker.cljs
@@ -1,0 +1,47 @@
+(ns hti.re-dash-inspector.worker
+  (:require
+   [cljs.reader :as r]
+   [clojure.data :as data]
+   [clojure.walk :as walk]))
+
+(defn- sanitize
+  "Transforms an app DB snapshot before performing a diff."
+  [m]
+
+  (walk/postwalk
+   (fn [el]
+     (if (map-entry? el)
+       (let [[key val] el]
+         [key
+
+          (cond
+            ;; Empty maps behave weirdly when doing clojure.data/diff
+            ;; Here we merely reset them to {}
+            (and (map? val) (empty? val)) {}
+            ;; Empty lists behave weirdly when doing clojure.data/diff
+            ;; Here we merely reset them to '()
+            (and (list? val) (empty? val)) '()
+
+            :else val)])
+       el))
+   m))
+
+(defn- on-message
+  "Produces a diff on a pair of app DB snapshots for the inspector's recording feature."
+  [event]
+
+  (let [data (some-> event .-data r/read-string)
+        event-id (:rd.inspector.event/id data)
+        event-number (:rd.inspector.event/number data)
+        db-before (:rd.inspector.event/db-before data)
+        db-after (:rd.inspector.event/db-after data)
+        diff (take 2 (data/diff (sanitize db-before) (sanitize db-after)))]
+
+    (.postMessage
+     js/self
+
+     (prn-str {:rd.inspector.event/id event-id
+               :rd.inspector.event/number event-number
+               :rd.inspector.event/diff diff}))))
+
+(set! (.-onmessage js/self) on-message)


### PR DESCRIPTION
### TL;DR

* This PR proposes a CLJS implementation for `worker.js`.
* This is an alternative approach to #2 which was introduced in an attempt to eliminate the dependency on `dart:html` for web workers.

### Why?

It appears that the main issue blocking the #2 approach is that the compiled ClojureDart code for the closure passed to `listen` in `worker.dart` cannot be transformed to JS code.

My best guest is that Dart's new JS inter-op does not respond well to dynamic types in the function signature. 

While I was able to use a type hint to produce an explicit return type in the compiled output of the ClojureDart code, the function parameters were always marked as dynamic and only cast to the type within the function body.

There may be a way to get it to work with enough stubbornness; but there is a much simpler solution.

### Conclusion

The CLJS approach eliminates the `dart:html`, albeit in a round-about way, and maintains the expected behaviour for the recording feature in the inspector.

### PS

Like with the CLJD implementation, a `bb.edn` file is provided with a `compile` command that writes the output to `./worker.js`. I have omitted the output in this PR for brevity.

